### PR TITLE
Feature/add multi tax support

### DIFF
--- a/lib/zatca/ubl/common_aggregate_components/tax_category.rb
+++ b/lib/zatca/ubl/common_aggregate_components/tax_category.rb
@@ -18,7 +18,7 @@ class ZATCA::UBL::CommonAggregateComponents::TaxCategory < ZATCA::UBL::BaseCompo
   def initialize(
     tax_percent: "15.00", id: "S", scheme_agency_id: "6",
     scheme_id: "UN/ECE 5305", tax_scheme_id: "VAT",
-    tax_scheme_scheme_id: "UN/ECE 5153", tax_exemption_reason_code: nil
+    tax_scheme_scheme_id: "UN/ECE 5153", tax_exemption_reason_code: nil, tax_exemption_reason: nil
   )
     super()
 
@@ -29,6 +29,7 @@ class ZATCA::UBL::CommonAggregateComponents::TaxCategory < ZATCA::UBL::BaseCompo
     @tax_scheme_id = tax_scheme_id
     @tax_scheme_scheme_id = tax_scheme_scheme_id
     @tax_exemption_reason_code = tax_exemption_reason_code
+    @tax_exemption_reason = tax_exemption_reason
   end
 
   def name
@@ -38,8 +39,9 @@ class ZATCA::UBL::CommonAggregateComponents::TaxCategory < ZATCA::UBL::BaseCompo
   def elements
     [
       ZATCA::UBL::BaseComponent.new(name: "cbc:ID", value: @id, attributes: {"schemeAgencyID" => @scheme_agency_id, "schemeID" => @scheme_id}.compact),
-      tax_exemption_reason_code_element,
       ZATCA::UBL::BaseComponent.new(name: "cbc:Percent", value: @tax_percent),
+      tax_exemption_reason_code_element,
+      tax_exemption_reason_reason_text_element,
       ZATCA::UBL::BaseComponent.new(name: "cac:TaxScheme", elements: [
         ZATCA::UBL::BaseComponent.new(name: "cbc:ID", value: @tax_scheme_id, attributes: {"schemeAgencyID" => @scheme_agency_id, "schemeID" => @tax_scheme_scheme_id}.compact)
       ])
@@ -51,6 +53,11 @@ class ZATCA::UBL::CommonAggregateComponents::TaxCategory < ZATCA::UBL::BaseCompo
   def tax_exemption_reason_code_element
     if @tax_exemption_reason_code.present?
       ZATCA::UBL::BaseComponent.new(name: "cbc:TaxExemptionReasonCode", value: @tax_exemption_reason_code)
+    end
+  end
+  def tax_exemption_reason_reason_text_element
+    if @tax_exemption_reason.present?
+      ZATCA::UBL::BaseComponent.new(name: "cbc:TaxExemptionReason", value: @tax_exemption_reason)
     end
   end
 end

--- a/lib/zatca/ubl/common_aggregate_components/tax_subtotal.rb
+++ b/lib/zatca/ubl/common_aggregate_components/tax_subtotal.rb
@@ -1,0 +1,59 @@
+class ZATCA::UBL::CommonAggregateComponents::TaxSubtotal < ZATCA::UBL::BaseComponent
+# This class represents the <cac:TaxSubtotal> component used within <cac:TaxTotal> blocks.
+# According to ZATCA e-invoicing specifications, invoices must include two distinct <cac:TaxTotal> sections:
+# 1. One summarizing the overall tax amount.
+# 2. Another containing one or more <cac:TaxSubtotal> entries, each describing tax details by category.
+#
+# Each <cac:TaxSubtotal> element must correspond to a specific tax category (e.g., 'S' for standard rate, 'Z' for zero rate).
+# This class enables the creation of multiple subtotal entries, ensuring proper grouping and structure for VAT breakdowns
+# in compliance with ZATCA Phase 2 XML UBL formatting.
+
+# <cac:TaxTotal> --> this tag for total invoice i think.
+#   <cbc:TaxAmount currencyID="SAR">30.15</cbc:TaxAmount>
+# </cac:TaxTotal>
+# <cac:TaxTotal> --> this tag must hold taxSubtotals
+#   <cbc:TaxAmount currencyID="SAR">30.15</cbc:TaxAmount>
+#   <cac:TaxSubtotal>
+#     <cbc:TaxableAmount currencyID="SAR">201.00</cbc:TaxableAmount>
+#     <cbc:TaxAmount currencyID="SAR">30.15</cbc:TaxAmount>
+#     <cac:TaxCategory>
+#       <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+#       <cbc:Percent>15.00</cbc:Percent>
+#       <cac:TaxScheme>
+#         <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+#       </cac:TaxScheme>
+#     </cac:TaxCategory>
+#   </cac:TaxSubtotal>
+#   <cac:TaxSubtotal>
+#     <cbc:TaxableAmount currencyID="SAR">201.00</cbc:TaxableAmount>
+#     <cbc:TaxAmount currencyID="SAR">30.15</cbc:TaxAmount>
+#     <cac:TaxCategory>
+#       <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+#       <cbc:Percent>15.00</cbc:Percent>
+#       <cac:TaxScheme>
+#         <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+#       </cac:TaxScheme>
+#     </cac:TaxCategory>
+#   </cac:TaxSubtotal>
+# </cac:TaxTotal>
+
+  def initialize(taxable_amount:, tax_amount:, tax_category:, currency_id: "SAR")
+    super()
+    @taxable_amount = taxable_amount
+    @tax_amount = tax_amount
+    @tax_category = tax_category || ZATCA::UBL::CommonAggregateComponents::TaxCategory.new
+    @currency_id = currency_id
+  end
+
+  def name
+    "cac:TaxSubtotal"
+  end
+
+  def elements
+    [
+      ZATCA::UBL::BaseComponent.new(name: "cbc:TaxableAmount", value: @taxable_amount, attributes: { "currencyID" => @currency_id }),
+      ZATCA::UBL::BaseComponent.new(name: "cbc:TaxAmount", value: @tax_amount, attributes: { "currencyID" => @currency_id }),
+      @tax_category
+    ]
+  end
+end

--- a/lib/zatca/ubl/common_aggregate_components/tax_total.rb
+++ b/lib/zatca/ubl/common_aggregate_components/tax_total.rb
@@ -1,45 +1,58 @@
 class ZATCA::UBL::CommonAggregateComponents::TaxTotal < ZATCA::UBL::BaseComponent
   # <cac:TaxTotal>
-  # <cbc:TaxAmount currencyID="SAR">144.9</cbc:TaxAmount>
-  # <cac:TaxSubtotal>
-  #     <cbc:TaxableAmount currencyID="SAR">966.00</cbc:TaxableAmount>
-  #     <cbc:TaxAmount currencyID="SAR">144.90</cbc:TaxAmount>
+  #   <cbc:TaxAmount currencyID="SAR">97.5</cbc:TaxAmount>
+  #   <cac:TaxSubtotal>
+  #     <cbc:TaxableAmount currencyID="SAR">650.0</cbc:TaxableAmount>
+  #     <cbc:TaxAmount currencyID="SAR">97.5</cbc:TaxAmount>
   #     <cac:TaxCategory>
-  #         <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
-  #         <cbc:Percent>15.00</cbc:Percent>
-  #         <cac:TaxScheme>
-  #             <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
-  #         </cac:TaxScheme>
+  #       <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+  #       <cbc:Percent>15</cbc:Percent>
+  #       <cac:TaxScheme>
+  #         <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+  #       </cac:TaxScheme>
   #     </cac:TaxCategory>
-  # </cac:TaxSubtotal>
+  #   </cac:TaxSubtotal>
+  #   <cac:TaxSubtotal>
+  #     <cbc:TaxableAmount currencyID="SAR">650.0</cbc:TaxableAmount>
+  #     <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+  #     <cac:TaxCategory>
+  #       <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">Z</cbc:ID>
+  #       <cbc:Percent>0.00</cbc:Percent>
+  #       <cbc:TaxExemptionReasonCode>VATEX-SA-32</cbc:TaxExemptionReasonCode>
+  #       <cbc:TaxExemptionReason>Zero rated due to exemption</cbc:TaxExemptionReason>
+  #       <cac:TaxScheme>
+  #         <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+  #       </cac:TaxScheme>
+  #     </cac:TaxCategory>
+  #   </cac:TaxSubtotal>
   # </cac:TaxTotal>
-
   def initialize(
-    tax_amount:, tax_subtotal_amount: nil, taxable_amount: nil,
-    rounding_amount: nil, tax_category: nil, currency_id: "SAR"
+    tax_amount:,tax_subtotal_amount: nil, rounding_amount: nil, currency_id: "SAR", tax_category: nil, taxable_amount: nil, tax_subtotals: []
   )
     super()
-
     @tax_amount = tax_amount
-    @tax_subtotal_amount = tax_subtotal_amount
-    @taxable_amount = taxable_amount
     @rounding_amount = rounding_amount
     @tax_category = tax_category || ZATCA::UBL::CommonAggregateComponents::TaxCategory.new
     @currency_id = currency_id
+    @taxable_amount = taxable_amount
+    @tax_subtotal_amount = tax_subtotal_amount
+
+    @tax_subtotals = if @taxable_amount.present? && @tax_subtotal_amount.present? && @tax_category.present? && tax_subtotals.blank?
+      [
+        ZATCA::UBL::CommonAggregateComponents::TaxSubtotal.new(
+          taxable_amount: @taxable_amount,
+          tax_amount: @tax_subtotal_amount,
+          tax_category: @tax_category,
+          currency_id: @currency_id
+        )
+      ]
+    else
+      tax_subtotals
+    end
   end
 
   def name
     "cac:TaxTotal"
-  end
-
-  def tax_subtotal_element
-    if @taxable_amount.present? && @tax_subtotal_amount.present? && @tax_category.present?
-      ZATCA::UBL::BaseComponent.new(name: "cac:TaxSubtotal", elements: [
-        ZATCA::UBL::BaseComponent.new(name: "cbc:TaxableAmount", value: @taxable_amount, attributes: {"currencyID" => @currency_id}),
-        ZATCA::UBL::BaseComponent.new(name: "cbc:TaxAmount", value: @tax_subtotal_amount, attributes: {"currencyID" => @currency_id}),
-        @tax_category
-      ])
-    end
   end
 
   def rounding_amount_element
@@ -50,9 +63,13 @@ class ZATCA::UBL::CommonAggregateComponents::TaxTotal < ZATCA::UBL::BaseComponen
 
   def elements
     [
-      ZATCA::UBL::BaseComponent.new(name: "cbc:TaxAmount", value: @tax_amount, attributes: {"currencyID" => @currency_id}),
+      ZATCA::UBL::BaseComponent.new(
+        name: "cbc:TaxAmount",
+        value: @tax_amount,
+        attributes: { "currencyID" => @currency_id }
+      ),
       rounding_amount_element,
-      tax_subtotal_element
-    ]
+      *@tax_subtotals # each is a TaxSubtotal and responds to `#name` and `#elements`
+    ].compact
   end
 end

--- a/spec/fixtures/simplified_invoice.rb
+++ b/spec/fixtures/simplified_invoice.rb
@@ -98,6 +98,38 @@ TAX_TOTALS = [
   )
 ].freeze
 
+TAX_TOTALS_MULTI_TAX_TYPE = [
+  ZATCA::UBL::CommonAggregateComponents::TaxTotal.new(
+    tax_amount: "15"
+  ),
+  ZATCA::UBL::CommonAggregateComponents::TaxTotal.new(
+    tax_amount: "15",
+    tax_subtotal_amount: "15",
+    taxable_amount: "100",
+    # for each id of taxCategory, we need to create a taxSubtotal; if we have 4 items with id "S", we need to create 1 taxSubtotal for that id.
+    # and so on with "Z" or "E"
+    tax_subtotals: [
+      ZATCA::UBL::CommonAggregateComponents::TaxSubtotal.new(
+        taxable_amount: "100",
+        tax_amount: "15",
+        tax_category: ZATCA::UBL::CommonAggregateComponents::TaxCategory.new(
+          tax_percent: "15.00"
+        )
+      ),
+      ZATCA::UBL::CommonAggregateComponents::TaxSubtotal.new(
+        taxable_amount: "500",
+        tax_amount: "0.00",
+        tax_category: ZATCA::UBL::CommonAggregateComponents::TaxCategory.new(
+          id: 'Z',
+          tax_percent: '0.00',
+          tax_exemption_reason_code: 'VATEX-SA-32',
+          tax_exemption_reason: 'Zero rated due to exemption'
+        )
+      )
+    ]
+  )
+].freeze
+
 LEGAL_MONETARY_TOTAL = ZATCA::UBL::CommonAggregateComponents::LegalMonetaryTotal.new(
   line_extension_amount: "201.00",
   tax_exclusive_amount: "201.00",
@@ -105,6 +137,15 @@ LEGAL_MONETARY_TOTAL = ZATCA::UBL::CommonAggregateComponents::LegalMonetaryTotal
   allowance_total_amount: "0.00",
   prepaid_amount: "0.00",
   payable_amount: "231.15"
+).freeze
+
+LEGAL_MONETARY_TOTAL_MULTI_TAX_TYPE = ZATCA::UBL::CommonAggregateComponents::LegalMonetaryTotal.new(
+  line_extension_amount: "600.00",
+  tax_exclusive_amount: "600.00",
+  tax_inclusive_amount: "615.00",
+  allowance_total_amount: "0.00",
+  prepaid_amount: "0.00",
+  payable_amount: "615.00"
 ).freeze
 
 INVOICE_LINES = [
@@ -157,6 +198,68 @@ INVOICE_LINES = [
   )
 ].freeze
 
+INVOICE_LINES_MULTI_TAX_TYPE = [
+  # Gold 21k
+  ZATCA::UBL::CommonAggregateComponents::InvoiceLine.new(
+    invoiced_quantity: "1",
+    invoiced_quantity_unit_code: "PCE",
+    line_extension_amount: "100.00",
+    tax_total: ZATCA::UBL::CommonAggregateComponents::TaxTotal.new(
+      tax_amount: "15",
+      rounding_amount: "115"
+    ),
+    item: ZATCA::UBL::CommonAggregateComponents::Item.new(
+      name: "ذهب عيار 21"
+    ),
+    price: ZATCA::UBL::CommonAggregateComponents::Price.new(
+      price_amount: "100.00",
+      allowance_charge: ZATCA::UBL::CommonAggregateComponents::AllowanceCharge.new(
+        charge_indicator: false,
+        allowance_charge_reason: "discount",
+        amount: "0.00",
+        add_tax_category: false,
+        add_id: false
+      )
+    )
+  ),
+
+  # Gold 24k
+  ZATCA::UBL::CommonAggregateComponents::InvoiceLine.new(
+    invoiced_quantity: "2",
+    invoiced_quantity_unit_code: "GRM",
+    line_extension_amount: "500.00",
+    tax_total: ZATCA::UBL::CommonAggregateComponents::TaxTotal.new(
+      tax_amount: "0.00",
+      rounding_amount: "500.00",
+      tax_category: ZATCA::UBL::CommonAggregateComponents::TaxCategory.new(
+        id: 'Z',
+        tax_percent: '0.00',
+        tax_exemption_reason_code: 'VATEX-SA-32',
+        tax_exemption_reason: 'Zero rated due to exemption'
+      )
+    ),
+    item: ZATCA::UBL::CommonAggregateComponents::Item.new(
+      name: "ذهب عيار 24",
+      # we need to modify id for zero VAT code.
+      classified_tax_category: ZATCA::UBL::CommonAggregateComponents::ClassifiedTaxCategory.new(
+        id: 'Z',
+        percent: '0.00'
+      )
+    ),
+    price: ZATCA::UBL::CommonAggregateComponents::Price.new(
+      price_amount: "250.00",
+      allowance_charge: ZATCA::UBL::CommonAggregateComponents::AllowanceCharge.new(
+        charge_indicator: false,
+        allowance_charge_reason: "discount",
+        amount: "0.00",
+        add_tax_category: false,
+        add_id: false
+      )
+    )
+  )
+].freeze
+
+
 CURRENCY_CODE = "SAR".freeze
 
 def make_invoice(signature: nil, qr_code: nil)
@@ -186,6 +289,33 @@ def make_invoice(signature: nil, qr_code: nil)
   )
 end
 
+def make_multi_tax_type_invoice(signature: nil, qr_code: nil)
+  ZATCA::UBL::Invoice.new(
+    add_ids_to_allowance_charges: false,
+    signature: signature,
+    qr_code: qr_code,
+    id: INVOICE_ID,
+    uuid: INVOICE_UUID,
+    issue_date: ISSUE_DATE,
+    issue_time: ISSUE_TIME,
+    subtype: INVOICE_SUBTYPE,
+    type: INVOICE_TYPE,
+    invoice_counter_value: INVOICE_COUNTER_VALUE,
+    previous_invoice_hash: PREVIOUS_INVOICE_HASH,
+    accounting_supplier_party: ACCOUNTING_SUPPLIER_PARTY,
+    accounting_customer_party: ACCOUNTING_CUSTOMER_PARTY,
+    delivery: DELIVERY,
+    payment_means_code: PAYMENT_MEANS_CODE,
+    allowance_charges: ALLOWANCE_CHARGES,
+    tax_totals: TAX_TOTALS_MULTI_TAX_TYPE,
+    legal_monetary_total: LEGAL_MONETARY_TOTAL_MULTI_TAX_TYPE,
+    invoice_lines: INVOICE_LINES_MULTI_TAX_TYPE,
+    currency_code: CURRENCY_CODE,
+    note: NOTE,
+    note_language_id: NOTE_LANGUAGE_ID
+  )
+end
+
 def construct_simplified_invoice
   signature = ZATCA::UBL::Signing::Signature.new(
     invoice_hash: "o4RpnVmSAttoj1roBwPSEn8RM4Yaid4NPa2/lffpqkQ=",
@@ -203,6 +333,27 @@ def construct_simplified_invoice
   make_invoice(signature: signature, qr_code: qr_code)
 end
 
+def construct_simplified_invoice_multi_tax_type
+  signature = ZATCA::UBL::Signing::Signature.new(
+    invoice_hash: "o4RpnVmSAttoj1roBwPSEn8RM4Yaid4NPa2/lffpqkQ=",
+    signed_properties_hash: "OGU1M2Q3NGFkOTdkYTRiNDVhOGZmYmU2ZjE0YzI3ZDhhNjlmM2EzZmQ4MTU5NTBhZjBjNDU2MWZlNjU3MWU0ZQ==",
+    signature_value: "MEYCIQDYsDnviJYPgYjyCIYAyzETeYthIoJaQhChblP4eAAPPAIhAJl6zfHgiKmWTtsfUz8YBZ8QkQ9rBL4Uy7mK0cxvWooH",
+    certificate: "MIID6jCCA5CgAwIBAgITbwAAgdnaFeERlUnosgABAACB2TAKBggqhkjOPQQDAjBjMRUwEwYKCZImiZPyLGQBGRYFbG9jYWwxEzARBgoJkiaJk/IsZAEZFgNnb3YxFzAVBgoJkiaJk/IsZAEZFgdleHRnYXp0MRwwGgYDVQQDExNUU1pFSU5WT0lDRS1TdWJDQS0xMB4XDTIyMTExMzA4MTQwNloXDTI0MTExMjA4MTQwNlowTjELMAkGA1UEBhMCU0ExEzARBgNVBAoTCjMxMTExMTExMTExDDAKBgNVBAsTA1RTVDEcMBoGA1UEAxMTVFNULTMxMTExMTExMTEwMTExMzBWMBAGByqGSM49AgEGBSuBBAAKA0IABGGDDKDmhWAITDv7LXqLX2cmr6+qddUkpcLCvWs5rC2O29W/hS4ajAK4Qdnahym6MaijX75Cg3j4aao7ouYXJ9GjggI5MIICNTCBmgYDVR0RBIGSMIGPpIGMMIGJMTswOQYDVQQEDDIxLVRTVHwyLVRTVHwzLTNiYjUwNzUyLTczZTktNGZkMS05Y2FmLTk5MDMxZTg2NzYwOTEfMB0GCgmSJomT8ixkAQEMDzMxMTExMTExMTEwMTExMzENMAsGA1UEDAwEMTEwMDEMMAoGA1UEGgwDVFNUMQwwCgYDVQQPDANUU1QwHQYDVR0OBBYEFDuWYlOzWpFN3no1WtyNktQdrA8JMB8GA1UdIwQYMBaAFHZgjPsGoKxnVzWdz5qspyuZNbUvME4GA1UdHwRHMEUwQ6BBoD+GPWh0dHA6Ly90c3RjcmwuemF0Y2EuZ292LnNhL0NlcnRFbnJvbGwvVFNaRUlOVk9JQ0UtU3ViQ0EtMS5jcmwwga0GCCsGAQUFBwEBBIGgMIGdMG4GCCsGAQUFBzABhmJodHRwOi8vdHN0Y3JsLnphdGNhLmdvdi5zYS9DZXJ0RW5yb2xsL1RTWkVpbnZvaWNlU0NBMS5leHRnYXp0Lmdvdi5sb2NhbF9UU1pFSU5WT0lDRS1TdWJDQS0xKDEpLmNydDArBggrBgEFBQcwAYYfaHR0cDovL3RzdGNybC56YXRjYS5nb3Yuc2Evb2NzcDAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMDMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwMwCgYIKoZIzj0EAwIDSAAwRQIgaHfuXVSkdtyfxmbM32OZzobhX/za+GV4my0HiZkaj88CIQCDDFZ0pHH13kH0fv2gauv7PtsdTYsDRixr8BjyRv1AMw==",
+    signing_time: "2022-09-15T00:41:21",
+    cert_digest_value: "YTJkM2JhYTcwZTBhZTAxOGYwODMyNzY3NTdkZDM3YzhjY2IxOTIyZDZhM2RlZGJiMGY0NDUzZWJhYWI4MDhmYg==",
+    cert_issuer_name: "CN=TSZEINVOICE-SubCA-1, DC=extgazt, DC=gov, DC=local",
+    cert_serial_number: "2475382889638462342007062736671525055900975577"
+  )
+
+  qr_code = "ARNBY21lIFdpZGdldOKAmXMgTFREAg8zMTExMTExMTExMDExMTMDFDIwMjItMDgtMTdUMTc6NDE6MDhaBAYyMzEuMTUFBTMwLjE1BixSdkNTcE1ZejgwMDlLYkoza3U3Mm9hQ0ZXcHpFZlFOY3BjKzVidWxoM0prPQdgTUVZQ0lRRFlzRG52aUpZUGdZanlDSVlBeXpFVGVZdGhJb0phUWhDaGJsUDRlQUFQUEFJaEFKbDZ6ZkhnaUttV1R0c2ZVejhZQlo4UWtROXJCTDRVeTdtSzBjeHZXb29ICFgwVjAQBgcqhkjOPQIBBgUrgQQACgNCAARhgwyg5oVgCEw7+y16i19nJq+vqnXVJKXCwr1rOawtjtvVv4UuGowCuEHZ2ocpujGoo1++QoN4+GmqO6LmFyfRCUYwRAIgOgjNPJW017lsIijmVQVkP7GzFO2KQKd9GHaukLgIWFsCIFJF9uwKhTMxDjWbN+1awsnFI7RLBRxA/6hZ+F1wtaqU"
+
+  make_multi_tax_type_invoice(signature: signature, qr_code: qr_code)
+end
+
 def construct_unsigned_simplified_invoice
   make_invoice
+end
+
+def construct_unsigned_simplified_invoice_multi_tax_type
+  make_multi_tax_type_invoice
 end

--- a/spec/fixtures/xml/simplified_invoice_multi_tax_type_signed.xml
+++ b/spec/fixtures/xml/simplified_invoice_multi_tax_type_signed.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+  <ext:UBLExtensions>
+    <ext:UBLExtension>
+      <ext:ExtensionURI>urn:oasis:names:specification:ubl:dsig:enveloped:xades</ext:ExtensionURI>
+      <ext:ExtensionContent>
+        <sig:UBLDocumentSignatures xmlns:sig="urn:oasis:names:specification:ubl:schema:xsd:CommonSignatureComponents-2" xmlns:sac="urn:oasis:names:specification:ubl:schema:xsd:SignatureAggregateComponents-2" xmlns:sbc="urn:oasis:names:specification:ubl:schema:xsd:SignatureBasicComponents-2">
+          <sac:SignatureInformation>
+            <cbc:ID>urn:oasis:names:specification:ubl:signature:1</cbc:ID>
+            <sbc:ReferencedSignatureID>urn:oasis:names:specification:ubl:signature:Invoice</sbc:ReferencedSignatureID>
+            <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="signature">
+              <ds:SignedInfo>
+                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2006/12/xml-c14n11"/>
+                <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+                <ds:Reference Id="invoiceSignedData" URI="">
+                  <ds:Transforms>
+                    <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
+                      <ds:XPath>not(//ancestor-or-self::ext:UBLExtensions)</ds:XPath>
+                    </ds:Transform>
+                    <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
+                      <ds:XPath>not(//ancestor-or-self::cac:Signature)</ds:XPath>
+                    </ds:Transform>
+                    <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
+                      <ds:XPath>not(//ancestor-or-self::cac:AdditionalDocumentReference[cbc:ID='QR'])</ds:XPath>
+                    </ds:Transform>
+                    <ds:Transform Algorithm="http://www.w3.org/2006/12/xml-c14n11"/>
+                  </ds:Transforms>
+                  <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                  <ds:DigestValue>o4RpnVmSAttoj1roBwPSEn8RM4Yaid4NPa2/lffpqkQ=</ds:DigestValue>
+                </ds:Reference>
+                <ds:Reference Type="http://www.w3.org/2000/09/xmldsig#SignatureProperties" URI="#xadesSignedProperties">
+                  <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                  <ds:DigestValue>OGU1M2Q3NGFkOTdkYTRiNDVhOGZmYmU2ZjE0YzI3ZDhhNjlmM2EzZmQ4MTU5NTBhZjBjNDU2MWZlNjU3MWU0ZQ==</ds:DigestValue>
+                </ds:Reference>
+              </ds:SignedInfo>
+              <ds:SignatureValue>MEYCIQDYsDnviJYPgYjyCIYAyzETeYthIoJaQhChblP4eAAPPAIhAJl6zfHgiKmWTtsfUz8YBZ8QkQ9rBL4Uy7mK0cxvWooH</ds:SignatureValue>
+              <ds:KeyInfo>
+                <ds:X509Data>
+                  <ds:X509Certificate>MIID6jCCA5CgAwIBAgITbwAAgdnaFeERlUnosgABAACB2TAKBggqhkjOPQQDAjBjMRUwEwYKCZImiZPyLGQBGRYFbG9jYWwxEzARBgoJkiaJk/IsZAEZFgNnb3YxFzAVBgoJkiaJk/IsZAEZFgdleHRnYXp0MRwwGgYDVQQDExNUU1pFSU5WT0lDRS1TdWJDQS0xMB4XDTIyMTExMzA4MTQwNloXDTI0MTExMjA4MTQwNlowTjELMAkGA1UEBhMCU0ExEzARBgNVBAoTCjMxMTExMTExMTExDDAKBgNVBAsTA1RTVDEcMBoGA1UEAxMTVFNULTMxMTExMTExMTEwMTExMzBWMBAGByqGSM49AgEGBSuBBAAKA0IABGGDDKDmhWAITDv7LXqLX2cmr6+qddUkpcLCvWs5rC2O29W/hS4ajAK4Qdnahym6MaijX75Cg3j4aao7ouYXJ9GjggI5MIICNTCBmgYDVR0RBIGSMIGPpIGMMIGJMTswOQYDVQQEDDIxLVRTVHwyLVRTVHwzLTNiYjUwNzUyLTczZTktNGZkMS05Y2FmLTk5MDMxZTg2NzYwOTEfMB0GCgmSJomT8ixkAQEMDzMxMTExMTExMTEwMTExMzENMAsGA1UEDAwEMTEwMDEMMAoGA1UEGgwDVFNUMQwwCgYDVQQPDANUU1QwHQYDVR0OBBYEFDuWYlOzWpFN3no1WtyNktQdrA8JMB8GA1UdIwQYMBaAFHZgjPsGoKxnVzWdz5qspyuZNbUvME4GA1UdHwRHMEUwQ6BBoD+GPWh0dHA6Ly90c3RjcmwuemF0Y2EuZ292LnNhL0NlcnRFbnJvbGwvVFNaRUlOVk9JQ0UtU3ViQ0EtMS5jcmwwga0GCCsGAQUFBwEBBIGgMIGdMG4GCCsGAQUFBzABhmJodHRwOi8vdHN0Y3JsLnphdGNhLmdvdi5zYS9DZXJ0RW5yb2xsL1RTWkVpbnZvaWNlU0NBMS5leHRnYXp0Lmdvdi5sb2NhbF9UU1pFSU5WT0lDRS1TdWJDQS0xKDEpLmNydDArBggrBgEFBQcwAYYfaHR0cDovL3RzdGNybC56YXRjYS5nb3Yuc2Evb2NzcDAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMDMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwMwCgYIKoZIzj0EAwIDSAAwRQIgaHfuXVSkdtyfxmbM32OZzobhX/za+GV4my0HiZkaj88CIQCDDFZ0pHH13kH0fv2gauv7PtsdTYsDRixr8BjyRv1AMw==</ds:X509Certificate>
+                </ds:X509Data>
+              </ds:KeyInfo>
+              <ds:Object>
+                            <xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Target="signature">
+                                <xades:SignedProperties Id="xadesSignedProperties">
+                                    <xades:SignedSignatureProperties>
+                                        <xades:SigningTime>2022-09-15T00:41:21</xades:SigningTime>
+                                        <xades:SigningCertificate>
+                                            <xades:Cert>
+                                                <xades:CertDigest>
+                                                    <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                                                    <ds:DigestValue>YTJkM2JhYTcwZTBhZTAxOGYwODMyNzY3NTdkZDM3YzhjY2IxOTIyZDZhM2RlZGJiMGY0NDUzZWJhYWI4MDhmYg==</ds:DigestValue>
+                                                </xades:CertDigest>
+                                                <xades:IssuerSerial>
+                                                    <ds:X509IssuerName>CN=TSZEINVOICE-SubCA-1, DC=extgazt, DC=gov, DC=local</ds:X509IssuerName>
+                                                    <ds:X509SerialNumber>2475382889638462342007062736671525055900975577</ds:X509SerialNumber>
+                                                </xades:IssuerSerial>
+                                            </xades:Cert>
+                                        </xades:SigningCertificate>
+                                    </xades:SignedSignatureProperties>
+                                </xades:SignedProperties>
+                            </xades:QualifyingProperties>
+              </ds:Object>
+            </ds:Signature>
+          </sac:SignatureInformation>
+        </sig:UBLDocumentSignatures>
+      </ext:ExtensionContent>
+    </ext:UBLExtension>
+  </ext:UBLExtensions>
+  <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+  <cbc:ID>SME00010</cbc:ID>
+  <cbc:UUID>8e6000cf-1a98-4174-b3e7-b5d5954bc10d</cbc:UUID>
+  <cbc:IssueDate>2022-08-17</cbc:IssueDate>
+  <cbc:IssueTime>17:41:08</cbc:IssueTime>
+  <cbc:InvoiceTypeCode name="0200000">388</cbc:InvoiceTypeCode>
+  <cbc:Note languageID="ar">ABC</cbc:Note>
+  <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>ICV</cbc:ID>
+    <cbc:UUID>10</cbc:UUID>
+  </cac:AdditionalDocumentReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>PIH</cbc:ID>
+    <cac:Attachment>
+      <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>QR</cbc:ID>
+    <cac:Attachment>
+      <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">ARNBY21lIFdpZGdldOKAmXMgTFREAg8zMTExMTExMTExMDExMTMDFDIwMjItMDgtMTdUMTc6NDE6MDhaBAYyMzEuMTUFBTMwLjE1BixSdkNTcE1ZejgwMDlLYkoza3U3Mm9hQ0ZXcHpFZlFOY3BjKzVidWxoM0prPQdgTUVZQ0lRRFlzRG52aUpZUGdZanlDSVlBeXpFVGVZdGhJb0phUWhDaGJsUDRlQUFQUEFJaEFKbDZ6ZkhnaUttV1R0c2ZVejhZQlo4UWtROXJCTDRVeTdtSzBjeHZXb29ICFgwVjAQBgcqhkjOPQIBBgUrgQQACgNCAARhgwyg5oVgCEw7+y16i19nJq+vqnXVJKXCwr1rOawtjtvVv4UuGowCuEHZ2ocpujGoo1++QoN4+GmqO6LmFyfRCUYwRAIgOgjNPJW017lsIijmVQVkP7GzFO2KQKd9GHaukLgIWFsCIFJF9uwKhTMxDjWbN+1awsnFI7RLBRxA/6hZ+F1wtaqU</cbc:EmbeddedDocumentBinaryObject>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:Signature>
+    <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+    <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+  </cac:Signature>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="CRN">324223432432432</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:StreetName>الامير سلطان</cbc:StreetName>
+        <cbc:BuildingNumber>3242</cbc:BuildingNumber>
+        <cbc:PlotIdentification>4323</cbc:PlotIdentification>
+        <cbc:CitySubdivisionName>32423423</cbc:CitySubdivisionName>
+        <cbc:CityName>الرياض | Riyadh</cbc:CityName>
+        <cbc:PostalZone>32432</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>311111111101113</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Acme Widgets LTD</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PostalAddress>
+        <cbc:CitySubdivisionName>32423423</cbc:CitySubdivisionName>
+        <cac:Country>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
+  </cac:PaymentMeans>
+  <cac:AllowanceCharge>
+    <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+    <cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>
+    <cbc:Amount currencyID="SAR">0.00</cbc:Amount>
+    <cac:TaxCategory>
+      <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+      <cbc:Percent>15</cbc:Percent>
+      <cac:TaxScheme>
+        <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+      </cac:TaxScheme>
+    </cac:TaxCategory>
+    <cac:TaxCategory>
+      <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+      <cbc:Percent>15</cbc:Percent>
+      <cac:TaxScheme>
+        <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+      </cac:TaxScheme>
+    </cac:TaxCategory>
+  </cac:AllowanceCharge>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="SAR">15</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="SAR">15</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="SAR">100</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="SAR">15</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+        <cbc:Percent>15.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="SAR">500</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">Z</cbc:ID>
+        <cbc:Percent>0.00</cbc:Percent>
+        <cbc:TaxExemptionReasonCode>VATEX-SA-32</cbc:TaxExemptionReasonCode>
+        <cbc:TaxExemptionReason>Zero rated due to exemption</cbc:TaxExemptionReason>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="SAR">600.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="SAR">600.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="SAR">615.00</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="SAR">0.00</cbc:AllowanceTotalAmount>
+    <cbc:PrepaidAmount currencyID="SAR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="SAR">615.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="SAR">15</cbc:TaxAmount>
+      <cbc:RoundingAmount currencyID="SAR">115</cbc:RoundingAmount>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>ذهب عيار 21</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="SAR">100.00</cbc:PriceAmount>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="SAR">0.00</cbc:Amount>
+      </cac:AllowanceCharge>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="GRM">2</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="SAR">500.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+      <cbc:RoundingAmount currencyID="SAR">500.00</cbc:RoundingAmount>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>ذهب عيار 24</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>Z</cbc:ID>
+        <cbc:Percent>0.00</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="SAR">250.00</cbc:PriceAmount>
+      <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="SAR">0.00</cbc:Amount>
+      </cac:AllowanceCharge>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/spec/lib/zatca/ubl/invoice_spec.rb
+++ b/spec/lib/zatca/ubl/invoice_spec.rb
@@ -13,6 +13,13 @@ describe ZATCA::UBL::Invoice do
       expect(invoice.generate_xml(canonicalized: false, spaces: 2)).to eq(zatca_xml)
     end
 
+    it "should generate multi-tax-type xml that matches ZATCA's" do
+      invoice = construct_simplified_invoice_multi_tax_type
+      zatca_xml = read_xml_fixture("simplified_invoice_multi_tax_type_signed.xml")
+
+      expect(invoice.generate_xml(canonicalized: false, spaces: 2)).to eq(zatca_xml)
+    end
+
     it "should be able to create an unsigned invoice qr-less invoice then add them later" do
       invoice = construct_unsigned_simplified_invoice
 


### PR DESCRIPTION
This PR introduces support for generating multiple <cac:TaxSubtotal> entries in compliance with ZATCA Phase 2 XML formatting.

- Refactored TaxTotal to accept an array of TaxSubtotal objects.
- Added fallback logic for backward compatibility.
- Introduced TaxSubtotal class to represent structured breakdowns by tax category (S, Z, etc.).
- Added RSpec test to validate multi-tax XML output against ZATCA fixture.

This change ensures the invoice complies with ZATCA's requirement to separate tax totals per tax category.